### PR TITLE
trickle down from Values.global

### DIFF
--- a/charts/database/templates/database-deployment.yaml
+++ b/charts/database/templates/database-deployment.yaml
@@ -43,7 +43,7 @@ spec:
               value: "{{.Values.postgres.timeout}}"
 {{- if eq .Values.global.storage "s3" }}
             - name: S3_SSE
-              value: "{{.Values.s3.use_sse}}"
+              value: "{{.Values.global.s3.use_sse}}"
 {{- end}}
           lifecycle:
             preStop:


### PR DESCRIPTION
values in workflow/values.yaml only trickle down for use in dependant charts
when they are in the global section